### PR TITLE
Fix GitHub release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.ref_name }}
           files: app.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- specify a tag when publishing releases

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872e8eb3b488328a43d3759e4b7db79