### PR TITLE
Handle runtime errors with logging and message box

### DIFF
--- a/password_manager.py
+++ b/password_manager.py
@@ -8,6 +8,7 @@ from tkinter import messagebox, ttk
 import pyperclip
 from cryptography.fernet import Fernet
 import ttkbootstrap as tb
+import logging
 
 # Fixed key for symmetric encryption
 _KEY = b'510xYPt3EyKwn27amFGZYjbQnO83TvM44AUZ_MtKSXM='
@@ -17,6 +18,13 @@ if getattr(sys, 'frozen', False):
 else:
     BASE_DIR = Path(__file__).parent
 DATA_FILE = BASE_DIR / 'data.vault'
+LOG_FILE = BASE_DIR / 'error.log'
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.ERROR)
+handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+logger.addHandler(handler)
 
 class PasswordManager(tb.Window):
     def __init__(self):
@@ -130,5 +138,12 @@ class PasswordManager(tb.Window):
                 self.entries = []
 
 if __name__ == "__main__":
-    app = PasswordManager()
-    app.mainloop()
+    try:
+        app = PasswordManager()
+        app.mainloop()
+    except Exception as e:
+        logger.exception("Unhandled exception")
+        try:
+            messagebox.showerror("Error", str(e))
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- show meaningful runtime errors to the user
- log errors in `error.log`

## Testing
- `python -m py_compile password_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6873fecfe32c8328b923e04619ac81d8