### PR TITLE
Restore release on feature branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: '${{ github.ref_name }}-${{ github.run_number }}'
+          name: 'Build ${{ github.run_number }}'
           files: app.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The executable will be located in `dist/password_manager/`.
 
 ## GitHub Actions
 The repository includes a workflow that builds the executable and attaches a zip
-archive to a release when pushing to branches named `feature/**`. The workflow
-grants `contents: write` permission to `GITHUB_TOKEN` so it can publish the
-release automatically.
+archive to a release whenever code is pushed to a branch matching `feature/**`.
+Each run publishes a new release tagged with the branch name and the workflow
+run number. The workflow grants `contents: write` permission to `GITHUB_TOKEN`
+so it can publish the release automatically.


### PR DESCRIPTION
## Summary
- build and publish a release when pushing to `feature/**`
- use workflow run number to tag each build
- clarify README about release workflow

## Testing
- `python -m py_compile password_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68741c51a84c8328b8b4c58589035555