### PR TITLE
Fix README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ python password_manager.py
 To build a portable version, use pyinstaller:
 
 ```bash
-pyinstaller --noconfirm --onefolder password_manager.py
+pip install -r requirements.txt
+pyinstaller --noconfirm --onedir --hidden-import pyperclip password_manager.py
 ```
 
 The executable will be located in `dist/password_manager/`.


### PR DESCRIPTION
## Summary
- fix README: correct PyInstaller command and mention installing deps

## Testing
- `python -m py_compile password_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874362bcc148328bdaf310b795614cb