### PR TITLE
Fix theme initialization

### DIFF
--- a/password_manager.py
+++ b/password_manager.py
@@ -20,7 +20,12 @@ DATA_FILE = BASE_DIR / 'data.vault'
 
 class PasswordManager(tb.Window):
     def __init__(self):
-        super().__init__(themename="flatly")
+        super().__init__()
+        # ttkbootstrap already exposes a ``style`` property, which returns the
+        # internal ``Style`` instance.  Assigning to ``self.style`` would raise
+        # ``AttributeError`` because the property has no setter.  Use the
+        # ``theme_use`` method instead to apply the desired theme.
+        self.style.theme_use("flatly")
         self.title("Password Manager")
         self.geometry("900x500")
         self.resizable(False, False)


### PR DESCRIPTION
## Summary
- set ttkbootstrap theme via the `style` property instead of assigning

## Testing
- `python -m py_compile password_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68743e75712c8328bf9f7d9ada4df3dd