### PR TITLE
Fix style configuration

### DIFF
--- a/password_manager.py
+++ b/password_manager.py
@@ -21,6 +21,10 @@ DATA_FILE = BASE_DIR / 'data.vault'
 class PasswordManager(tb.Window):
     def __init__(self):
         super().__init__(themename="flatly")
+        # Apply the desired theme and configure widget styles
+        # using the existing ``style`` property from ``ttkbootstrap``.
+        self.style.theme_use("flatly")
+        self.style.configure("Treeview", rowheight=25)
         self.title("Password Manager")
         self.geometry("900x500")
         self.resizable(False, False)


### PR DESCRIPTION
## Summary
- use the existing `style` property to apply the theme
- configure a `Treeview` style without reassigning `self.style`

## Testing
- `python -m py_compile password_manager.py`
- `python password_manager.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6874407a8b7c8328a2941e70b45034db