### PR TITLE
Fix Treeview row styling bug

### DIFF
--- a/password_manager.py
+++ b/password_manager.py
@@ -51,6 +51,8 @@ class PasswordManager(tb.Window):
     def _populate_table(self):
         for item in self.tree.get_children():
             self.tree.delete(item)
+        # configure background color for even rows using a theme-safe value
+        self.tree.tag_configure("even", background=self.style.colors.bg)
         for idx, entry in enumerate(self.entries):
             values = (
                 entry.get("title", ""),
@@ -59,7 +61,8 @@ class PasswordManager(tb.Window):
                 entry.get("url", ""),
                 entry.get("notes", ""),
             )
-            self.tree.insert("", "end", iid=str(idx), values=values)
+            tags = ("even",) if idx % 2 == 0 else ()
+            self.tree.insert("", "end", iid=str(idx), values=values, tags=tags)
 
     def _add_entry(self):
         dialog = tb.Toplevel(self)


### PR DESCRIPTION
## Summary
- style even rows with a theme-safe color

## Testing
- `python -m py_compile password_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_687443778ec883289dafa5b61332ccaf