### PR TITLE
Add application icon and build tweaks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Build executable
-        run: pyinstaller --noconfirm --onedir password_manager.py
+        run: pyinstaller --noconfirm --onedir --windowed --icon icon.ico password_manager.py
 
       - name: Create zip
         run: Compress-Archive -Path dist/password_manager/* -DestinationPath app.zip

--- a/password_manager.py
+++ b/password_manager.py
@@ -45,6 +45,14 @@ class PasswordManager(tb.Window):
         style.map("Treeview", background=[("selected", style.colors.primary)])
 
         self.title("Password Manager")
+        icon_path = BASE_DIR / "icon.ico"
+        if icon_path.exists():
+            try:
+                self.icon_img = tk.PhotoImage(file=icon_path)
+                self.iconphoto(False, self.icon_img)
+            except Exception:
+                logger.exception("Failed to set window icon")
+
         self.geometry("900x500")
         self.resizable(True, True)
         self.columnconfigure(0, weight=1)


### PR DESCRIPTION
## Summary
- display `icon.ico` as the Tk window icon
- build release executable without console window and include the icon

## Testing
- `python -m py_compile password_manager.py`
- `pyinstaller --noconfirm --onedir --windowed --icon icon.ico password_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6875bdfff8c08328be7fd9c74843e798